### PR TITLE
feat: add route support with React Router

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,14 @@
     "": {
       "name": "react-starter-minimal",
       "version": "0.0.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@prismicio/client": "^6.5.1",
         "@prismicio/helpers": "^2.3.0",
         "@prismicio/react": "^2.4.1",
         "react": "^18.1.0",
-        "react-dom": "^18.1.0"
+        "react-dom": "^18.1.0",
+        "react-router-dom": "^6.3.0"
       },
       "devDependencies": {
         "@types/react": "^18.0.10",
@@ -1717,7 +1719,6 @@
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.3.tgz",
       "integrity": "sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -5923,6 +5924,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -8592,6 +8601,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "dependencies": {
+        "history": "^5.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "dependencies": {
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
@@ -8669,8 +8702,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.0",
@@ -11986,7 +12018,6 @@
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.3.tgz",
       "integrity": "sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -15088,6 +15119,14 @@
         }
       }
     },
+    "history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "requires": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -17061,6 +17100,23 @@
       "integrity": "sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==",
       "dev": true
     },
+    "react-router": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "requires": {
+        "history": "^5.2.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "requires": {
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
+      }
+    },
     "readable-stream": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
@@ -17134,8 +17190,7 @@
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "regenerator-transform": {
       "version": "0.15.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "@prismicio/helpers": "^2.3.0",
     "@prismicio/react": "^2.4.1",
     "react": "^18.1.0",
-    "react-dom": "^18.1.0"
+    "react-dom": "^18.1.0",
+    "react-router-dom": "^6.3.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.10",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,25 +1,10 @@
-import {
-  usePrismicDocumentByUID,
-  PrismicText,
-  SliceZone,
-} from "@prismicio/react";
-
-import { components } from "../slices";
+import { Outlet } from "react-router-dom";
 
 function App() {
-  const [page, { state }] = usePrismicDocumentByUID("page", "home");
-
-  if (state !== "loaded") {
-    return <div>Loading&hellip;</div>;
-  }
-
   return (
-    <div>
-      <h1>
-        <PrismicText field={page.data.title} />
-      </h1>
-      <SliceZone slices={page.data.slices} components={components} />
-    </div>
+    <main>
+      <Outlet />
+    </main>
   );
 }
 

--- a/src/Page.jsx
+++ b/src/Page.jsx
@@ -1,0 +1,36 @@
+import { useParams } from "react-router-dom";
+import {
+  usePrismicDocumentByUID,
+  PrismicText,
+  SliceZone,
+} from "@prismicio/react";
+
+import { components } from "../slices";
+
+function Page({ uid: uidOverride }) {
+  const params = useParams();
+  const uid = uidOverride || params.uid;
+
+  const [page, { state }] = usePrismicDocumentByUID("page", uid, {
+    skip: !Boolean(uid),
+  });
+
+  switch (state) {
+    case "loading": {
+      return <div>Loading&hellip;</div>;
+    }
+
+    case "loaded": {
+      return (
+        <div>
+          <h1>
+            <PrismicText field={page.data.title} />
+          </h1>
+          <SliceZone slices={page.data.slices} components={components} />
+        </div>
+      );
+    }
+  }
+}
+
+export default Page;

--- a/src/Preview.jsx
+++ b/src/Preview.jsx
@@ -1,0 +1,13 @@
+import { usePrismicPreviewResolver } from "@prismicio/react";
+
+import { useNavigate } from "react-router-dom";
+
+function Preview() {
+  const navigate = useNavigate();
+
+  usePrismicPreviewResolver({ navigate });
+
+  return <div>Loading&hellip;</div>;
+}
+
+export default Preview;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,16 +1,28 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { PrismicProvider, PrismicToolbar } from "@prismicio/react";
-import App from "./App";
 
-import { createClient, repositoryName } from "../prismicio";
+import { createClient, linkResolver, repositoryName } from "../prismicio";
+
+import App from "./App";
+import Page from "./Page";
+import Preview from "./Preview";
 
 const client = createClient();
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <PrismicProvider client={client}>
-      <App />
+    <PrismicProvider client={client} linkResolver={linkResolver}>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<App />}>
+            <Route index element={<Page uid="home" />} />
+            <Route path="preview" element={<Preview />} />
+            <Route path=":uid" element={<Page />} />
+          </Route>
+        </Routes>
+      </BrowserRouter>
       <PrismicToolbar repositoryName={repositoryName} />
     </PrismicProvider>
   </React.StrictMode>


### PR DESCRIPTION
This PR adds route support via [React Router][react-router]. The following new functionality to supported as a result:

- Each Page document in the Prismic repository has an associated URL.
- The `/preview` route redirects a content writer to the correct route for the previewed document.

Most React applications will need a router, and React Router is the most popular solution.

[react-router]: https://reactrouter.com/
